### PR TITLE
Small improvement for devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "mounts": [
         "source=press-f-ultra-bashhistory,target=/commandhistory,type=volume"
     ],
-    "workspaceMount": "source=${localWorkspaceFolder}/,target=/workspace,type=bind",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "workspaceFolder": "/workspace",
     "postCreateCommand": "rm -rf ./libdragon && git clone https://github.com/dragonminded/libdragon -b preview --depth 1 && cd ./libdragon && make clobber -j && make libdragon tools -j && make install tools-install -j && make -j4",
     "customizations": {


### PR DESCRIPTION
The path contained an extra slash which is ignored, but better without it (for maintainability).